### PR TITLE
docker-compose mac m chip support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - MONGOURL=mongodb://db:27017
 
   db:
-    image: bitnami/mongodb
+    image: zcube/bitnami-compat-mongodb
     ports:
       - 27017:27017
     volumes:


### PR DESCRIPTION
Dev ortamı M serisi çip mac'te ayağa kalkmıyordu.
Docker flie bitnami imajı değiştirilmesi gerekti.
Diğer ortamlarlar için sorun olmuyorsa değişmiş image ile devam edilsin.

konu ile alakalı issue: https://forums.docker.com/t/mongodb-info-validating-settings-in-mongodb-env-vars-bitnami-stuck-loading-error/125368/3