### PR TITLE
Supply chain security basics: just the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm install --omit=dev
+RUN npm install --ignore-scripts --omit=dev
 
 COPY . .
 


### PR DESCRIPTION
`postinstall` scripts run when you call `npm install` and can do anything as current user. They are the most common vector of attack in malicious npm packages. Protecting against them is simple. Avoid running them.

This fixes the Dockerfile only. 
If you want more protection, see: https://github.com/acikkaynak/deprem-io-backend/pull/136